### PR TITLE
Add typing of values

### DIFF
--- a/bfa/lib/symex/excl.ml
+++ b/bfa/lib/symex/excl.ml
@@ -18,8 +18,8 @@ module Make (Symex : Symex.S) = struct
   let serialize serialize_val x = serialize_val x
   let pp_serialized = pp
 
-  let iter_vars_serialized (i : 'a -> Symex.Value.ty Var.iter_vars)
-      (x : 'a serialized) : Symex.Value.ty Var.iter_vars =
+  let iter_vars_serialized (i : 'a -> 'b Symex.Value.ty Var.iter_vars)
+      (x : 'a serialized) : 'b Symex.Value.ty Var.iter_vars =
    fun f -> i x f
 
   let subst_serialized subst_inner subst_var x = subst_inner subst_var x

--- a/bfa/lib/symex/plist.ml
+++ b/bfa/lib/symex/plist.ml
@@ -11,12 +11,12 @@ module type SInt_sig = sig
   include Stdlib.Map.OrderedType with type t := t
 
   val pp : t Fmt.t
-  val sem_eq : t -> t -> Value.t
+  val sem_eq : t -> t -> Value.sbool Value.t
   val of_int : int -> t
-  val in_range : t -> t * t -> Value.t
-  val greater_or_equal : t -> t -> Value.t
+  val in_range : t -> t * t -> Value.sbool Value.t
+  val greater_or_equal : t -> t -> Value.sbool Value.t
   val subst : (Var.t -> Var.t) -> t -> t
-  val iter_vars : t -> (Var.t * Value.ty -> unit) -> unit
+  val iter_vars : t -> (Var.t * 'a Value.ty -> unit) -> unit
 end
 
 module Make (Symex : Symex.S) (SInt : SInt_sig with module Symex = Symex) =

--- a/bfa/lib/symex/plist.ml
+++ b/bfa/lib/symex/plist.ml
@@ -10,11 +10,13 @@ module type SInt_sig = sig
 
   include Stdlib.Map.OrderedType with type t := t
 
+  type sbool_v := Value.sbool Value.t
+
   val pp : t Fmt.t
-  val sem_eq : t -> t -> Value.sbool Value.t
+  val sem_eq : t -> t -> sbool_v
   val of_int : int -> t
-  val in_range : t -> t * t -> Value.sbool Value.t
-  val greater_or_equal : t -> t -> Value.sbool Value.t
+  val in_range : t -> t * t -> sbool_v
+  val greater_or_equal : t -> t -> sbool_v
   val subst : (Var.t -> Var.t) -> t -> t
   val iter_vars : t -> (Var.t * 'a Value.ty -> unit) -> unit
 end

--- a/bfa/lib/symex/pmap.ml
+++ b/bfa/lib/symex/pmap.ml
@@ -1,15 +1,19 @@
 module type KeyS = sig
   type t
+  type kt
 
   module Symex : Symex.S
   include Stdlib.Map.OrderedType with type t := t
 
   val pp : t Fmt.t
-  val sem_eq : t -> t -> Symex.Value.t
-  val fresh : ?constrs:(t -> Symex.Value.t list) -> unit -> t Symex.t
-  val distinct : t list -> Symex.Value.t
+  val sem_eq : t -> t -> Symex.Value.sbool Symex.Value.t
+
+  val fresh :
+    ?constrs:(t -> Symex.Value.sbool Symex.Value.t list) -> unit -> t Symex.t
+
+  val distinct : t list -> Symex.Value.sbool Symex.Value.t
   val subst : (Var.t -> Var.t) -> t -> t
-  val iter_vars : t -> Symex.Value.ty Var.iter_vars
+  val iter_vars : t -> kt Symex.Value.ty Var.iter_vars
 end
 
 module Build_from_find_opt_sym

--- a/bfa/lib/symex/pmap.ml
+++ b/bfa/lib/symex/pmap.ml
@@ -1,6 +1,5 @@
 module type KeyS = sig
   type t
-  type kt
 
   module Symex : Symex.S
   include Stdlib.Map.OrderedType with type t := t
@@ -13,7 +12,7 @@ module type KeyS = sig
 
   val distinct : t list -> Symex.Value.sbool Symex.Value.t
   val subst : (Var.t -> Var.t) -> t -> t
-  val iter_vars : t -> kt Symex.Value.ty Var.iter_vars
+  val iter_vars : t -> 'a Symex.Value.ty Var.iter_vars
 end
 
 module Build_from_find_opt_sym

--- a/bfa/lib/symex/pmap.ml
+++ b/bfa/lib/symex/pmap.ml
@@ -4,13 +4,12 @@ module type KeyS = sig
   module Symex : Symex.S
   include Stdlib.Map.OrderedType with type t := t
 
+  type sbool_v := Symex.Value.sbool Symex.Value.t
+
   val pp : t Fmt.t
-  val sem_eq : t -> t -> Symex.Value.sbool Symex.Value.t
-
-  val fresh :
-    ?constrs:(t -> Symex.Value.sbool Symex.Value.t list) -> unit -> t Symex.t
-
-  val distinct : t list -> Symex.Value.sbool Symex.Value.t
+  val sem_eq : t -> t -> sbool_v
+  val fresh : ?constrs:(t -> sbool_v list) -> unit -> t Symex.t
+  val distinct : t list -> sbool_v
   val subst : (Var.t -> Var.t) -> t -> t
   val iter_vars : t -> 'a Symex.Value.ty Var.iter_vars
 end

--- a/bfa/lib/symex/solver.ml
+++ b/bfa/lib/symex/solver.ml
@@ -5,16 +5,17 @@ module type Mutable_incremental = sig
   module Value : Value.S
 
   (** simplified indicates if constraits were already simplified *)
-  val add_constraints : t -> ?simplified:bool -> Value.t list -> unit
+  val add_constraints :
+    t -> ?simplified:bool -> Value.sbool Value.t list -> unit
 
   val sat : t -> bool
 
   (** Like [sat] but may return true for now even though the constraint isn't
       actually sat. Therefore batching the sat checks *)
 
-  val simplify : t -> Value.t -> Value.t
-  val fresh_var : t -> Value.ty -> Var.t
-  val as_values : t -> Value.t list
+  val simplify : t -> 'a Value.t -> 'a Value.t
+  val fresh_var : t -> 'a Value.ty -> Var.t
+  val as_values : t -> 'a Value.t list
 end
 
 module type In_place_incremental = sig
@@ -22,16 +23,16 @@ module type In_place_incremental = sig
   module Value : Value.S
 
   (** simplified indicates if constraits were already simplified *)
-  val add_constraints : ?simplified:bool -> Value.t list -> unit
+  val add_constraints : ?simplified:bool -> Value.sbool Value.t list -> unit
 
   val sat : unit -> bool
 
   (** Like [sat] but may return true for now even though the constraint isn't
       actually sat. Therefore batching the sat checks *)
 
-  val simplify : Value.t -> Value.t
-  val fresh_var : Value.ty -> Var.t
-  val as_values : unit -> Value.t list
+  val simplify : 'a Value.t -> 'a Value.t
+  val fresh_var : 'a Value.ty -> Var.t
+  val as_values : unit -> 'a Value.t list
 end
 
 module Mutable_to_in_place (M : Mutable_incremental) = struct

--- a/bfa/lib/symex/solver.ml
+++ b/bfa/lib/symex/solver.ml
@@ -15,7 +15,7 @@ module type Mutable_incremental = sig
 
   val simplify : t -> 'a Value.t -> 'a Value.t
   val fresh_var : t -> 'a Value.ty -> Var.t
-  val as_values : t -> 'a Value.t list
+  val as_values : t -> Value.sbool Value.t list
 end
 
 module type In_place_incremental = sig

--- a/bfa/lib/symex/solver.ml
+++ b/bfa/lib/symex/solver.ml
@@ -4,9 +4,10 @@ module type Mutable_incremental = sig
   include Incremental.Mutable
   module Value : Value.S
 
+  type sbool_v := Value.sbool Value.t
+
   (** simplified indicates if constraits were already simplified *)
-  val add_constraints :
-    t -> ?simplified:bool -> Value.sbool Value.t list -> unit
+  val add_constraints : t -> ?simplified:bool -> sbool_v list -> unit
 
   val sat : t -> bool
 
@@ -15,7 +16,7 @@ module type Mutable_incremental = sig
 
   val simplify : t -> 'a Value.t -> 'a Value.t
   val fresh_var : t -> 'a Value.ty -> Var.t
-  val as_values : t -> Value.sbool Value.t list
+  val as_values : t -> sbool_v list
 end
 
 module type In_place_incremental = sig

--- a/bfa/lib/symex/substs.ml
+++ b/bfa/lib/symex/substs.ml
@@ -1,9 +1,9 @@
 module type From_iter = sig
   type t
-  type ty
+  type 'a ty
   type 'a symex
 
-  val from_iter : ty Var.iter_vars -> t symex
+  val from_iter : 'a ty Var.iter_vars -> t symex
 end
 
 module Subst = struct
@@ -36,7 +36,7 @@ module Subst = struct
   module From_iter (Symex : Symex.S) :
     From_iter
       with type t := Var.t t
-       and type ty := Symex.Value.ty
+       and type 'a ty := 'a Symex.Value.ty
        and type 'a symex := 'a Symex.t = struct
     let from_iter iter_vars =
       let open Symex.Syntax in
@@ -72,7 +72,7 @@ module Subst_mut = struct
   module From_iter (Symex : Symex.S) :
     From_iter
       with type t := Var.t t
-       and type ty := Symex.Value.ty
+       and type 'a ty := 'a Symex.Value.ty
        and type 'a symex := 'a Symex.t = struct
     let from_iter iter_vars =
       let open Symex.Syntax in
@@ -101,7 +101,7 @@ module Bi_subst = struct
   module From_iter (Symex : Symex.S) :
     From_iter
       with type t := t
-       and type ty := Symex.Value.ty
+       and type 'a ty := 'a Symex.Value.ty
        and type 'a symex := 'a Symex.t = struct
     open Symex.Syntax
 

--- a/bfa/lib/symex/symex.ml
+++ b/bfa/lib/symex/symex.ml
@@ -4,15 +4,19 @@ module type Base = sig
   module Value : Value.S
   module MONAD : Monad.Base
 
-  val assume : Value.t list -> unit MONAD.t
+  type 'a v := 'a Value.t
+  type 'a vt := 'a Value.ty
+  type sbool := Value.sbool
+
+  val assume : sbool v list -> unit MONAD.t
   val vanish : unit -> 'a MONAD.t
-  val assert_ : Value.t -> bool MONAD.t
-  val nondet : ?constrs:(Value.t -> Value.t list) -> Value.ty -> Value.t MONAD.t
-  val fresh_var : Value.ty -> Var.t MONAD.t
+  val assert_ : sbool v -> bool MONAD.t
+  val nondet : ?constrs:('a v -> sbool v list) -> 'a vt -> 'a v MONAD.t
+  val fresh_var : 'a vt -> Var.t MONAD.t
   val batched : (unit -> 'a MONAD.t) -> 'a MONAD.t
 
   val branch_on :
-    Value.t ->
+    sbool v ->
     then_:(unit -> 'a MONAD.t) ->
     else_:(unit -> 'a MONAD.t) ->
     'a MONAD.t
@@ -22,7 +26,7 @@ module type Base = sig
       [else_] branch is ignored, otherwise the [else_] branch is taken. This is,
       of course, UX-sound, but not OX-sound. *)
   val branch_on_take_one :
-    Value.t ->
+    sbool v ->
     then_:(unit -> 'a MONAD.t) ->
     else_:(unit -> 'a MONAD.t) ->
     'a MONAD.t
@@ -36,7 +40,7 @@ module type Base = sig
   (** [run] p actually performs symbolic execution and returns a list of
       obtained branches which capture the outcome together with a path condition
       that is a list of boolean symbolic values *)
-  val run : 'a MONAD.t -> ('a * Value.t list) list
+  val run : 'a MONAD.t -> ('a * sbool v list) list
 end
 
 module type S = sig
@@ -100,10 +104,16 @@ module type S = sig
 
     module Symex_syntax : sig
       val branch_on :
-        Value.t -> then_:(unit -> 'a t) -> else_:(unit -> 'a t) -> 'a t
+        Value.sbool Value.t ->
+        then_:(unit -> 'a t) ->
+        else_:(unit -> 'a t) ->
+        'a t
 
       val branch_on_take_one :
-        Value.t -> then_:(unit -> 'a t) -> else_:(unit -> 'a t) -> 'a t
+        Value.sbool Value.t ->
+        then_:(unit -> 'a t) ->
+        else_:(unit -> 'a t) ->
+        'a t
     end
   end
 end

--- a/bfa/lib/symex/symex.ml
+++ b/bfa/lib/symex/symex.ml
@@ -103,17 +103,13 @@ module type S = sig
     val ( let+? ) : ('a, 'b, 'c) Result.t -> ('c -> 'd) -> ('a, 'b, 'd) Result.t
 
     module Symex_syntax : sig
+      type sbool_v := Value.sbool Value.t
+
       val branch_on :
-        Value.sbool Value.t ->
-        then_:(unit -> 'a t) ->
-        else_:(unit -> 'a t) ->
-        'a t
+        sbool_v -> then_:(unit -> 'a t) -> else_:(unit -> 'a t) -> 'a t
 
       val branch_on_take_one :
-        Value.sbool Value.t ->
-        then_:(unit -> 'a t) ->
-        else_:(unit -> 'a t) ->
-        'a t
+        sbool_v -> then_:(unit -> 'a t) -> else_:(unit -> 'a t) -> 'a t
     end
   end
 end

--- a/bfa/lib/symex/value.ml
+++ b/bfa/lib/symex/value.ml
@@ -4,7 +4,7 @@ module type S = sig
   type sbool
 
   val not : sbool t -> sbool t
-  val sem_eq : 'a t -> 'b t -> sbool t
+  val sem_eq : 'a t -> 'a t -> sbool t
   val ppa : 'a t Fmt.t
   val iter_vars : 'a t -> 'b ty Var.iter_vars
   val subst : (Var.t -> Var.t) -> 'a t -> 'a t

--- a/bfa/lib/symex/value.ml
+++ b/bfa/lib/symex/value.ml
@@ -1,12 +1,13 @@
 module type S = sig
-  type t
-  type ty
+  type 'a t
+  type 'a ty
+  type sbool
 
-  val not : t -> t
-  val sem_eq : t -> t -> t
-  val pp : t Fmt.t
-  val iter_vars : t -> ty Var.iter_vars
-  val subst : (Var.t -> Var.t) -> t -> t
-  val mk_var : Var.t -> ty -> t
-  val as_bool : t -> bool option
+  val not : sbool t -> sbool t
+  val sem_eq : 'a t -> 'b t -> sbool t
+  val pp : 'a t Fmt.t
+  val iter_vars : 'a t -> 'a ty Var.iter_vars
+  val subst : (Var.t -> Var.t) -> 'a t -> 'a t
+  val mk_var : Var.t -> 'a ty -> 'a t
+  val as_bool : sbool t -> bool option
 end

--- a/bfa/lib/symex/value.ml
+++ b/bfa/lib/symex/value.ml
@@ -1,13 +1,13 @@
 module type S = sig
-  type 'a t
-  type 'a ty
+  type +'a t
+  type +'a ty
   type sbool
 
   val not : sbool t -> sbool t
   val sem_eq : 'a t -> 'b t -> sbool t
-  val pp : 'a t Fmt.t
-  val iter_vars : 'a t -> 'a ty Var.iter_vars
+  val ppa : 'a t Fmt.t
+  val iter_vars : 'a t -> 'b ty Var.iter_vars
   val subst : (Var.t -> Var.t) -> 'a t -> 'a t
   val mk_var : Var.t -> 'a ty -> 'a t
-  val as_bool : sbool t -> bool option
+  val as_bool : 'a t -> bool option
 end

--- a/bfa_c/lib/csymex.ml
+++ b/bfa_c/lib/csymex.ml
@@ -1,6 +1,15 @@
 module SYMEX = Bfa_symex.Symex.Make_iter (Z3solver)
 include SYMEX
 
+let check_nonzero (t : Typed.T.sint Typed.t) :
+    ([> Typed.T.nonzero ] Typed.t, [> `NonZeroIsZero ], 'fix) Result.t =
+  let open Syntax in
+  let open Typed.Infix in
+  if%sat t ==@ Typed.zero then Result.error `NonZeroIsZero
+  else Result.ok (Typed.cast t)
+
+(* sint t -> ([> nonzero ] t, [> `NonZeroIsZero ], 'fix) Csymex.Result.t *)
+
 let ( let@ ) = ( @@ )
 
 let push_give_up, flush_give_up =

--- a/bfa_c/lib/heap.mli
+++ b/bfa_c/lib/heap.mli
@@ -9,7 +9,7 @@ val serialize : t -> serialized
 val pp_serialized : Format.formatter -> serialized -> unit
 
 val iter_vars_serialized :
-  serialized -> (Svalue.Var.t * Svalue.ty -> unit) -> unit
+  serialized -> (Svalue.Var.t * [< Typed.T.cval ] Typed.ty -> unit) -> unit
 
 val subst_serialized :
   (Svalue.Var.t -> Svalue.Var.t) -> serialized -> serialized

--- a/bfa_c/lib/layout.ml
+++ b/bfa_c/lib/layout.ml
@@ -200,12 +200,12 @@ let nondet_c_ty (ty : ctype) : Typed.T.cval Typed.t Csymex.t =
   match proj_ctype_ ty with
   | Void -> Csymex.return 0s
   | Pointer _ ->
-      let* loc = Typed.nondet Typed.t_loc in
-      let* ofs = Typed.nondet Typed.t_int in
+      let* loc = Csymex.nondet Typed.t_loc in
+      let* ofs = Csymex.nondet Typed.t_int in
       Csymex.return (Typed.Ptr.mk loc ofs)
   | Basic (Integer ity) ->
       let constrs = int_constraints ity |> Option.get in
-      let+ res = Typed.nondet ~constrs Typed.t_int in
+      let+ res = Csymex.nondet ~constrs Typed.t_int in
       (res :> Typed.T.cval Typed.t)
   | Basic (Floating _) -> Csymex.not_impl "nondet_c_ty: floating"
   | Array _ | Function _ | FunctionNoParams _ | Struct _ | Union _ | Atomic _ ->

--- a/bfa_c/lib/svalue.ml
+++ b/bfa_c/lib/svalue.ml
@@ -57,6 +57,7 @@ and t_node = { kind : t_kind; ty : ty }
 and t = t_node hash_consed [@@deriving show { with_path = false }, eq, ord]
 
 let hash t = t.hkey
+let kind t = t.node.kind
 
 let rec iter_vars (sv : t) (f : Var.t * ty -> unit) : unit =
   match sv.node.kind with

--- a/bfa_c/lib/typed.ml
+++ b/bfa_c/lib/typed.ml
@@ -23,16 +23,18 @@ end
 
 type nonrec +'a t = t
 type nonrec +'a ty = ty
+type sbool = T.sbool
 
-let get_ty x = x.node.ty
+let[@inline] get_ty x = x.node.ty
+let[@inline] untype_type x = x
 let ppa = pp
 let pp _ = pp
 let ppa_ty = pp_ty
 let pp_ty _ = pp_ty
-let cast x = x
-let untyped x = x
-let untyped_list l = l
-let type_ x = x
+let[@inline] cast x = x
+let[@inline] untyped x = x
+let[@inline] untyped_list l = l
+let[@inline] type_ x = x
 let type_checked x ty = if equal_ty x.node.ty ty then Some x else None
 let cast_checked = type_checked
 
@@ -41,21 +43,3 @@ let nonzero_z z =
   else Svalue.int_z z
 
 let nonzero x = nonzero_z (Z.of_int x)
-
-let check_nonzero t =
-  let open Csymex.Syntax in
-  if%sat Infix.(t ==@ zero) then Csymex.Result.error `NonZeroIsZero
-  else Csymex.Result.ok t
-
-let nondet = Csymex.nondet
-let assume = Csymex.assume
-
-module Syntax = struct
-  module Symex_syntax = Csymex.SYMEX.Syntax.Symex_syntax
-
-  module Sym_int_syntax = struct
-    let mk_int = int
-    let zero = zero
-    let one = one
-  end
-end

--- a/bfa_c/lib/typed.mli
+++ b/bfa_c/lib/typed.mli
@@ -59,8 +59,8 @@ val compare : ([< any ] as 'a) t -> 'a t -> int
 
 (** Typed constructors *)
 
-val sem_eq : 'a t -> 'b t -> sbool t
-val sem_eq_untyped : 'a t -> 'b t -> [> sbool ] t
+val sem_eq : 'a t -> 'a t -> sbool t
+val sem_eq_untyped : 'a t -> 'a t -> [> sbool ] t
 val v_true : [> sbool ] t
 val v_false : [> sbool ] t
 val bool : bool -> [> sbool ] t

--- a/bfa_c/lib/typed.mli
+++ b/bfa_c/lib/typed.mli
@@ -25,10 +25,8 @@ open T
 (** {2 Types} *)
 type +'a ty
 
-val pp_ty :
-  (Format.formatter -> 'a ty -> unit) -> Format.formatter -> 'a ty -> unit
-
-val ppa_ty : Format.formatter -> 'a ty -> unit
+val pp_ty : 'a ty Fmt.t -> 'a ty Fmt.t
+val ppa_ty : 'a ty Fmt.t
 val t_bool : [> sbool ] ty
 val t_int : [> sint ] ty
 val t_ptr : [> sptr ] ty
@@ -38,18 +36,15 @@ val t_seq : ([< any ] as 'a) ty -> [> 'a sseq ] ty
 (** {2 Typed svalues} *)
 
 type +'a t
-
-(** Typed monadic operations *)
-
-val nondet :
-  ?constrs:(([< any ] as 'a) t -> [> sbool ] t list) -> 'a ty -> 'a t Csymex.t
-
-val assume : [> sbool ] t list -> unit Csymex.t
+type sbool = T.sbool
 
 (** Basic value operations *)
 
 val get_ty : 'a t -> Svalue.ty
-val iter_vars : 'a t -> (Svalue.Var.t * Svalue.ty -> unit) -> unit
+val untype_type : 'a ty -> Svalue.ty
+val kind : 'a t -> Svalue.t_kind
+val mk_var : Svalue.Var.t -> 'a ty -> 'a t
+val iter_vars : 'a t -> (Svalue.Var.t * 'b ty -> unit) -> unit
 val subst : (Svalue.Var.t -> Svalue.Var.t) -> 'a t -> 'a t
 val type_ : Svalue.t -> 'a t
 val type_checked : Svalue.t -> 'a ty -> 'a t option
@@ -57,22 +52,24 @@ val cast : 'a t -> 'b t
 val cast_checked : 'a t -> 'b ty -> 'b t option
 val untyped : 'a t -> Svalue.t
 val untyped_list : 'a t list -> Svalue.t list
-val pp : (Format.formatter -> 'a -> unit) -> Format.formatter -> 'a t -> unit
-val ppa : Format.formatter -> 'a t -> unit
+val pp : 'a Fmt.t -> 'a t Fmt.t
+val ppa : 'a t Fmt.t
 val equal : ([< any ] as 'a) t -> 'a t -> bool
 val compare : ([< any ] as 'a) t -> 'a t -> int
 
 (** Typed constructors *)
 
-val sem_eq : ([< any ] as 'a) t -> 'a t -> [> sbool ] t
+val sem_eq : 'a t -> 'b t -> sbool t
 val sem_eq_untyped : 'a t -> 'b t -> [> sbool ] t
 val v_true : [> sbool ] t
 val v_false : [> sbool ] t
 val bool : bool -> [> sbool ] t
+val as_bool : 'a t -> bool option
 val and_ : [< sbool ] t -> [< sbool ] t -> [> sbool ] t
 val conj : [< sbool ] t list -> [> sbool ] t
+val split_ands : [< sbool ] t -> ([> sbool ] t -> unit) -> unit
 val or_ : [< sbool ] t -> [< sbool ] t -> [> sbool ] t
-val not : [< sbool ] t -> [> sbool ] t
+val not : sbool t -> sbool t
 val not_int_bool : [< sint ] t -> [> sint ] t
 val distinct : 'a t list -> [> sbool ] t
 val int_z : Z.t -> [> sint ] t
@@ -91,9 +88,6 @@ val plus : [< sint ] t -> [< sint ] t -> [> sint ] t
 val minus : [< sint ] t -> [< sint ] t -> [> sint ] t
 val times : [< sint ] t -> [< sint ] t -> [> sint ] t
 val div : [< sint ] t -> nonzero t -> [> sint ] t
-
-val check_nonzero :
-  sint t -> ([> nonzero ] t, [> `NonZeroIsZero ], 'fix) Csymex.Result.t
 
 module Ptr : sig
   val mk : [< sloc ] t -> [< sint ] t -> [> sptr ] t
@@ -127,14 +121,6 @@ module Infix : sig
 end
 
 module Syntax : sig
-  module Symex_syntax : sig
-    val branch_on :
-      sbool t ->
-      then_:(unit -> 'a Csymex.t) ->
-      else_:(unit -> 'a Csymex.t) ->
-      'a Csymex.t
-  end
-
   module Sym_int_syntax : sig
     val mk_int : int -> [> sint ] t
     val zero : [> sint ] t

--- a/bfa_c/test/cram/bins/batch.ml
+++ b/bfa_c/test/cram/bins/batch.ml
@@ -4,10 +4,10 @@ open Csymex.Syntax
 let ( let@ ) = ( @@ )
 
 let process =
-  let open Svalue.Infix in
-  let open Svalue.Syntax in
+  let open Typed.Infix in
+  let open Typed.Syntax in
   let@ () = Csymex.batched in
-  let* n = Csymex.nondet Svalue.TInt in
+  let* n = Csymex.nondet Typed.t_int in
   let* () = Csymex.assume [ n >=@ 0s ] in
   let* () = Csymex.assume [ n <@ 10s ] in
   Csymex.assume [ n <@ 0s ]


### PR DESCRIPTION
Allow `Value.t` and `Value.ty` to carry type information; add `Value.sbool` to represent the type of symbolic booleans.
Update `bfa_c` accordingly, by making `Csymex` use `Typed` rather than `SValue`.