### PR TITLE
Parametric pointers

### DIFF
--- a/bfa_rust/lib/encoder.ml
+++ b/bfa_rust/lib/encoder.ml
@@ -7,7 +7,7 @@ open T
 open Charon_util
 open Rustsymex
 open Rustsymex.Syntax
-module Sptr = Sptr.T
+module Sptr = Sptr.ArithPtr
 open Layout
 
 type cval_info = {

--- a/bfa_rust/lib/encoder.ml
+++ b/bfa_rust/lib/encoder.ml
@@ -1,0 +1,275 @@
+open Utils
+open Charon
+open Typed
+open Typed.Syntax
+open Typed.Infix
+open T
+open Charon_util
+open Rustsymex
+open Rustsymex.Syntax
+module Sptr = Sptr.T
+open Layout
+
+type cval_info = {
+  value : cval Typed.t;
+  ty : Types.literal_type;
+  size : sint Typed.t;
+  offset : sint Typed.t;
+}
+
+(** Converts a Rust value of the given type into a list of C values, along with
+    their size and offset *)
+let rec rust_to_cvals ?(offset = 0s) (v : Sptr.t rust_val) (ty : Types.ty) :
+    cval_info list =
+  let illegal_pair () =
+    L.err (fun m ->
+        m "Wrong pair of rust_value and Charon.ty: %a / %a" ppa_rust_val v
+          Types.pp_ty ty);
+    failwith "Wrong pair of rust_value and Charon.ty"
+  in
+  let chain_cvals layout vals types =
+    List_ex.map2i
+      (fun i value ty ->
+        let offset = (Array.get layout.members_ofs i |> Typed.int) +@ offset in
+        rust_to_cvals ~offset value ty)
+      vals types
+    |> List.flatten
+  in
+
+  match (v, ty) with
+  (* Literals *)
+  | Base value, TLiteral ty ->
+      let size = Typed.int (size_of_literal_ty ty) in
+      [ { value; ty; size; offset } ]
+  | Ptr (value, None), TLiteral (TInteger (Isize | Usize) as ty) ->
+      let size = Typed.int (size_of_literal_ty ty) in
+      [ { value :> cval Typed.t; ty; size; offset } ]
+  | _, TLiteral _ -> illegal_pair ()
+  (* References / Pointers *)
+  | Ptr (value, meta), TAdt (TBuiltin TBox, { types = [ sub_ty ]; _ })
+  | Ptr (value, meta), TRef (_, sub_ty, _)
+  | Ptr (value, meta), TRawPtr (sub_ty, _) -> (
+      match (meta, is_fat_ptr sub_ty) with
+      | _, false ->
+          let size = Typed.int Archi.word_size in
+          [ { value :> cval Typed.t; ty = TInteger Isize; size; offset } ]
+      | Some meta, true ->
+          let size = Typed.int Archi.word_size in
+          let isize = Values.TInteger Isize in
+          [
+            { value :> cval Typed.t; ty = isize; size; offset };
+            { value = meta; ty = isize; size; offset = offset +@ size };
+          ]
+      | None, true -> failwith "Expected a fat pointer, got a thin pointer.")
+  (* References / Pointers obtained from casting *)
+  | Base value, TAdt (TBuiltin TBox, _)
+  | Base value, TRef _
+  | Base value, TRawPtr _ ->
+      let size = Typed.int Archi.word_size in
+      [ { value; ty = TInteger Isize; size; offset } ]
+  | _, TAdt (TBuiltin TBox, _) | _, TRawPtr _ | _, TRef _ -> illegal_pair ()
+  (* Tuples *)
+  | Tuple vs, TAdt (TTuple, { types; _ }) ->
+      if List.compare_lengths vs types <> 0 then
+        Fmt.failwith "Mistmached rust_val / TTuple lengths: %d/%d"
+          (List.length vs) (List.length types)
+      else chain_cvals (layout_of ty) vs types
+  | Tuple _, _ | _, TAdt (TTuple, _) -> illegal_pair ()
+  (* Structs *)
+  | Struct vals, TAdt (TAdtId t_id, _) ->
+      let type_decl = Session.get_adt t_id in
+      let fields =
+        match type_decl.kind with
+        | Struct fields -> field_tys fields
+        | _ ->
+            Fmt.failwith "Unexpected type declaration in struct value: %a"
+              Types.pp_type_decl type_decl
+      in
+      chain_cvals (layout_of ty) vals fields
+  | Struct _, _ -> illegal_pair ()
+  (* Enums *)
+  | Enum (disc, vals), TAdt (TAdtId t_id, _) ->
+      let type_decl = Session.get_adt t_id in
+      let disc_z =
+        match Typed.kind disc with
+        | Int d -> d
+        | k ->
+            Fmt.failwith "Unexpected enum discriminant kind: %a"
+              Svalue.pp_t_kind k
+      in
+      let variant =
+        match type_decl.kind with
+        | Enum variants ->
+            List.find
+              (fun v -> Z.equal disc_z Types.(v.discriminant.value))
+              variants
+        | _ ->
+            Fmt.failwith "Unexpected ADT type for enum: %a" Types.pp_type_decl
+              type_decl
+      in
+      let disc_ty = Types.TLiteral (TInteger variant.discriminant.int_ty) in
+      chain_cvals (of_variant variant) (Base disc :: vals)
+        (disc_ty :: field_tys variant.fields)
+  | Enum _, _ -> illegal_pair ()
+  (* Arrays *)
+  | Array vals, TAdt (TBuiltin TArray, { types = [ sub_ty ]; _ }) ->
+      let layout = layout_of ty in
+      let size = Array.length layout.members_ofs in
+      if List.length vals <> size then failwith "Array length mismatch"
+      else chain_cvals layout vals (List.init size (fun _ -> sub_ty))
+  | Array _, _ | _, TAdt (TBuiltin TArray, _) -> illegal_pair ()
+  (* Rest *)
+  | _ ->
+      L.err (fun m ->
+          m "Unhandled rust_value and Charon.ty: %a / %a" (pp_rust_val Sptr.pp)
+            v Types.pp_ty ty);
+      failwith "Unhandled rust_value and Charon.ty"
+
+type aux_ret =
+  (Types.literal_type * sint Typed.t * sint Typed.t) list * parse_callback
+
+and parse_callback = cval Typed.t list -> callback_return
+and parser_return = [ `Done of Sptr.t rust_val | `More of aux_ret ]
+and callback_return = parser_return Rustsymex.t
+
+(** Converts a Rust type into a list of C blocks, along with their size and
+    offset; once these are read, symbolically decides whether we must keep
+    reading. @offset is the initial offset to read from, @meta is the optional
+    metadata, that originates from a fat pointer. *)
+let rust_of_cvals ?offset ?meta ty : parser_return =
+  (* Base case, parses all types. *)
+  let rec aux offset : Types.ty -> parser_return = function
+    | TLiteral ty ->
+        `More
+          ( [ (ty, Typed.int (size_of_literal_ty ty), offset) ],
+            function
+            | [ v ] -> return (`Done (Base v))
+            | _ -> failwith "Expected one cval" )
+    | TAdt (TBuiltin TBox, { types = [ sub_ty ]; _ })
+    | TRef (_, sub_ty, _)
+    | TRawPtr (sub_ty, _)
+      when is_fat_ptr sub_ty ->
+        let callback = function
+          | [ ptr; len ] ->
+              let* ptr =
+                of_opt_not_impl ~msg:"Slice value 1 should be a pointer"
+                  (Typed.cast_checked ptr Typed.t_ptr)
+              in
+              let+ len =
+                of_opt_not_impl ~msg:"Slice value 2 should be an integer"
+                  (Typed.cast_checked len Typed.t_int)
+              in
+              `Done (Ptr (ptr, Some len))
+          | _ -> failwith "Expected two cvals"
+        in
+        let ptr_size = Typed.int Archi.word_size in
+        let isize = Values.TInteger Isize in
+        `More
+          ( [ (isize, ptr_size, offset); (isize, ptr_size, offset +@ ptr_size) ],
+            callback )
+    | TAdt (TBuiltin TBox, _) | TRef _ | TRawPtr _ ->
+        `More
+          ( [ (TInteger Isize, Typed.int Archi.word_size, offset) ],
+            function
+            | [ v ] -> (
+                match Typed.cast_checked v Typed.t_ptr with
+                | Some v_ptr -> return (`Done (Ptr (v_ptr, None)))
+                (* This should only happen on weird pointer casting. *)
+                | None -> return (`Done (Base v)))
+            | _ -> failwith "Expected one cval" )
+    | TAdt (TTuple, { types; _ }) as ty ->
+        let layout = layout_of ty in
+        aux_fields ~f:(fun fs -> Tuple fs) ~layout offset types
+    | TAdt (TAdtId t_id, _) as ty -> (
+        let type_decl = Session.get_adt t_id in
+        match (type_decl : Types.type_decl) with
+        | { kind = Enum variants; _ } -> aux_enum offset variants
+        | { kind = Struct fields; _ } ->
+            let layout = layout_of ty in
+            fields
+            |> field_tys
+            |> aux_fields ~f:(fun fs -> Struct fs) ~layout offset
+        | _ ->
+            Fmt.failwith "Unhandled type declaration in rust_of_cvals: %a"
+              Types.pp_type_decl type_decl)
+    | TAdt (TBuiltin TArray, { types = [ sub_ty ]; _ }) as ty ->
+        let layout = layout_of ty in
+        let len = Array.length layout.members_ofs in
+        let fields = List.init len (fun _ -> sub_ty) in
+        aux_fields ~f:(fun fs -> Array fs) ~layout offset fields
+    | TAdt (TBuiltin TSlice, { types = [ sub_ty ]; _ }) -> (
+        (* We can only read a slice if we have the metadata of its length, in which case
+           we interpret it as an array of that length. *)
+        match meta with
+        | None -> Fmt.failwith "Tried reading slice without metadata"
+        | Some meta ->
+            let len =
+              match Typed.kind meta with
+              | Int len -> Z.to_int len
+              | _ -> failwith "Can't read a slice of non-concrete size"
+            in
+            let arr_ty = mk_array_ty sub_ty len in
+            let layout = layout_of arr_ty in
+            let fields = List.init len (fun _ -> sub_ty) in
+            aux_fields ~f:(fun fs -> Array fs) ~layout offset fields)
+    | ty -> Fmt.failwith "Unhandled Charon.ty: %a" Types.pp_ty ty
+  (* Parses a list of fields (for structs and tuples) *)
+  and aux_fields ~f ~layout offset fields : parser_return =
+    let base_offset = offset +@ (offset %@ Typed.nonzero layout.align) in
+    let rec mk_callback to_parse parsed : parser_return =
+      match to_parse with
+      | [] -> `Done (f (List.rev parsed))
+      | ty :: rest -> (
+          let idx = List.length parsed in
+          let offset = Array.get layout.members_ofs idx |> Typed.int in
+          let offset = base_offset +@ offset in
+          match aux offset ty with
+          | `More (blocks, callback) ->
+              wrap_callback rest parsed blocks callback
+          | `Done value -> mk_callback rest (value :: parsed))
+    and wrap_callback to_parse parsed blocks callback =
+      `More
+        ( blocks,
+          fun values ->
+            let+ res = callback values in
+            match res with
+            | `More (blocks, callback) ->
+                wrap_callback to_parse parsed blocks callback
+            | `Done value -> mk_callback to_parse (value :: parsed) )
+    in
+    mk_callback fields []
+  (* Parses what enum variant we're handling *)
+  and aux_enum offset (variants : Types.variant list) : parser_return =
+    let disc = (List.hd variants).discriminant in
+    let disc_ty = Values.TInteger disc.int_ty in
+    let disc_align = Typed.nonzero (align_of_literal_ty disc_ty) in
+    let disc_size = Typed.int (size_of_literal_ty disc_ty) in
+    let offset = offset +@ (offset %@ disc_align) in
+    let callback cval : callback_return =
+      let cval = List.hd cval in
+      let* res =
+        match_on variants ~constr:(fun (v : Types.variant) ->
+            cval ==@ value_of_scalar v.discriminant)
+      in
+      match res with
+      | Some var ->
+          (* skip discriminant *)
+          let discr = value_of_scalar var.discriminant in
+          let ({ members_ofs = mems; _ } as layout) = of_variant var in
+          let members_ofs = Array.sub mems 1 (Array.length mems - 1) in
+          let layout = { layout with members_ofs } in
+          let parser =
+            var.fields
+            |> field_tys
+            |> aux_fields ~f:(fun fs -> Enum (discr, fs)) ~layout offset
+          in
+          return parser
+      | None ->
+          Fmt.kstr not_impl
+            "Vanishing rust_of_cvals, as no variant matches variant id %a"
+            Typed.ppa cval
+    in
+    `More ([ (TInteger disc.int_ty, disc_size, offset) ], callback)
+  in
+  let off = Option.value ~default:0s offset in
+  aux off ty

--- a/bfa_rust/lib/encoder.ml
+++ b/bfa_rust/lib/encoder.ml
@@ -134,8 +134,8 @@ and callback_return = parser_return Rustsymex.t
 
 (** Converts a Rust type into a list of C blocks, along with their size and
     offset; once these are read, symbolically decides whether we must keep
-    reading. @offset is the initial offset to read from, @meta is the optional
-    metadata, that originates from a fat pointer. *)
+    reading. [offset] is the initial offset to read from, [meta] is the optional
+    metadata, that originates from a fat pointer, used e.g. to read a slice. *)
 let rust_of_cvals ?offset ?meta ty : parser_return =
   (* Base case, parses all types. *)
   let rec aux offset : Types.ty -> parser_return = function

--- a/bfa_rust/lib/heap.ml
+++ b/bfa_rust/lib/heap.ml
@@ -107,7 +107,7 @@ let load ?is_move ((_, meta) as ptr) ty st =
   let@ () = with_error_loc_as_call_trace () in
   let@ () = with_loc_err () in
   log "load" ptr st;
-  if%sat Sptr.is_null ptr then Result.error `NullDereference
+  if%sat Sptr.is_at_null_loc ptr then Result.error `NullDereference
   else
     with_ptr ptr st (fun ~ofs block ->
         L.debug (fun f ->
@@ -148,7 +148,7 @@ let store ptr ty sval st =
   let@ () = with_error_loc_as_call_trace () in
   let@ () = with_loc_err () in
   log "store" ptr st;
-  if%sat Sptr.is_null ptr then Result.error `NullDereference
+  if%sat Sptr.is_at_null_loc ptr then Result.error `NullDereference
   else
     with_ptr ptr st (fun ~ofs block ->
         let parts = Encoder.rust_to_cvals ~offset:ofs sval ty in
@@ -167,7 +167,7 @@ let copy_nonoverlapping ~dst ~src ~size st =
   let open Typed.Infix in
   let@ () = with_error_loc_as_call_trace () in
   let@ () = with_loc_err () in
-  if%sat Sptr.is_null dst ||@ Sptr.is_null src then
+  if%sat Sptr.is_at_null_loc dst ||@ Sptr.is_at_null_loc src then
     Result.error `NullDereference
   else
     let** tree_to_write =
@@ -213,7 +213,7 @@ let uninit ptr ty st =
   let@ () = with_loc_err () in
   log "uninit" ptr st;
   let* size = Layout.size_of_s ty in
-  if%sat Sptr.is_null ptr then Result.error `NullDereference
+  if%sat Sptr.is_at_null_loc ptr then Result.error `NullDereference
   else
     with_ptr ptr st (fun ~ofs block -> Tree_block.uninit_range ofs size block)
 

--- a/bfa_rust/lib/heap.ml
+++ b/bfa_rust/lib/heap.ml
@@ -3,7 +3,7 @@ open Typed.Infix
 open Typed.Syntax
 module T = Typed.T
 open Rustsymex
-module Sptr = Sptr.T
+module Sptr = Sptr.ArithPtr
 
 type 'a err = 'a * Call_trace.t
 

--- a/bfa_rust/lib/interp.ml
+++ b/bfa_rust/lib/interp.ml
@@ -55,7 +55,7 @@ module Make (Heap : Heap_intf.S) = struct
             let++ (), st = Heap.free ptr st in
             st
         | Some ptr, Some protect ->
-            if%sat Sptr.eq ptr protect then Result.ok st
+            if%sat Sptr.sem_eq ptr protect then Result.ok st
             else
               let++ (), st = Heap.free ptr st in
               st)

--- a/bfa_rust/lib/layout.ml
+++ b/bfa_rust/lib/layout.ml
@@ -1,6 +1,6 @@
 module Utils_ = Utils
 open Charon
-open Rustsymex.Syntax
+open Typed
 open Typed.Infix
 open Typed.Syntax
 open Rustsymex
@@ -24,10 +24,6 @@ let pp_layout fmt { size; align; members_ofs } =
   Format.fprintf fmt "{ size = %d; align = %d; members_ofs = [%a] }" size align
     Fmt.(array ~sep:comma int)
     members_ofs
-
-type sint = Typed.T.sint Typed.t
-type cval = Typed.T.cval Typed.t
-type sbool = Typed.T.sbool Typed.t
 
 module Session = struct
   let current_crate : UllbcAst.crate ref =
@@ -114,7 +110,7 @@ let is_int : Types.ty -> bool = function
   | TLiteral (TInteger _) -> true
   | _ -> false
 
-let to_zeros : Types.literal_type -> cval = function
+let to_zeros : Types.literal_type -> T.cval Typed.t = function
   | TInteger _ -> 0s
   | t ->
       Fmt.failwith "to_zeros: unsupported literal type %a" Types.pp_literal_type
@@ -215,12 +211,13 @@ let rec layout_of (ty : Types.ty) : layout =
   | TArrow _ -> raise (CantComputeLayout ("Arrow", ty))
 
 and layout_of_members members =
+  let ( % ) = Stdlib.( mod ) in
   let rec aux members_ofs (layout : layout) = function
     | [] -> (List.rev members_ofs, layout)
     | ty :: rest ->
         let { size = curr_size; align = curr_align; _ } = layout in
         let { size; align; _ } = layout_of ty in
-        let mem_ofs = curr_size + ((align - (curr_size mod align)) mod align) in
+        let mem_ofs = curr_size + ((align - (curr_size % align)) % align) in
         let new_size = mem_ofs + size in
         let new_align = Int.max align curr_align in
         aux (mem_ofs :: members_ofs)
@@ -231,7 +228,7 @@ and layout_of_members members =
     aux [] { size = 0; align = 1; members_ofs = [||] } members
   in
   {
-    size = size + ((align - (size mod align)) mod align);
+    size = size + ((align - (size % align)) % align);
     align;
     members_ofs = Array.of_list members_ofs;
   }
@@ -308,7 +305,9 @@ let int_constraints ty =
   let max = max_value ty in
   fun x -> [ min <=@ x; x <=@ max ]
 
-let constraints : Types.literal_type -> (cval -> sbool list) option = function
+let constraints :
+    Types.literal_type -> (T.cval Typed.t -> T.sbool Typed.t list) option =
+  function
   | TInteger ity ->
       let constrs = int_constraints ity in
       Some
@@ -349,19 +348,17 @@ let constraints : Types.literal_type -> (cval -> sbool list) option = function
           m "No constraints implemented for type %a" Types.pp_literal_type ty);
       None
 
-let nondet_literal_ty : Types.literal_type -> cval Rustsymex.t =
-  let open Rustsymex.Syntax in
+let nondet_literal_ty : Types.literal_type -> T.cval Typed.t Rustsymex.t =
   function
   | (TInteger _ | TBool | TChar) as ty ->
       let constrs = Option.get @@ constraints ty in
-      let+ res = Rustsymex.nondet ~constrs Typed.t_int in
-      (res :> cval)
+      Rustsymex.nondet ~constrs Typed.t_int
   | ty ->
       Rustsymex.not_impl
         (Fmt.str "nondet_literal_ty: unsupported type %a" Types.pp_literal_type
            ty)
 
-let rec nondet : Types.ty -> rust_val Rustsymex.t =
+let rec nondet : Types.ty -> 'a rust_val Rustsymex.t =
   let open Rustsymex.Syntax in
   function
   | TLiteral lit ->
@@ -407,270 +404,3 @@ let rec nondet : Types.ty -> rust_val Rustsymex.t =
       Tuple fields
   | ty ->
       Rustsymex.not_impl (Fmt.str "nondet: unsupported type %a" Types.pp_ty ty)
-
-type cval_info = {
-  value : cval;
-  ty : Types.literal_type;
-  size : sint;
-  offset : sint;
-}
-
-(** Converts a Rust value of the given type into a list of C values, along with
-    their size and offset *)
-let rec rust_to_cvals ?(offset = 0s) (v : rust_val) (ty : Types.ty) :
-    cval_info list =
-  let illegal_pair () =
-    L.err (fun m ->
-        m "Wrong pair of rust_value and Charon.ty: %a / %a" pp_rust_val v
-          Types.pp_ty ty);
-    failwith "Wrong pair of rust_value and Charon.ty"
-  in
-  let chain_cvals layout vals types =
-    Utils_.List_ex.map2i
-      (fun i value ty ->
-        let offset = (Array.get layout.members_ofs i |> Typed.int) +@ offset in
-        rust_to_cvals ~offset value ty)
-      vals types
-    |> List.flatten
-  in
-
-  match (v, ty) with
-  (* Literals *)
-  | Base value, TLiteral ty ->
-      let size = Typed.int (size_of_literal_ty ty) in
-      [ { value; ty; size; offset } ]
-  | Ptr value, TLiteral (TInteger (Isize | Usize) as ty) ->
-      let size = Typed.int (size_of_literal_ty ty) in
-      [ { value :> cval; ty; size; offset } ]
-  | _, TLiteral _ -> illegal_pair ()
-  (* References / Pointers *)
-  | Ptr value, TAdt (TBuiltin TBox, _)
-  | Ptr value, TRef _
-  | Ptr value, TRawPtr _ ->
-      let size = Typed.int Archi.word_size in
-      [ { value :> cval; ty = TInteger Isize; size; offset } ]
-  (* References / Pointers obtained from casting *)
-  | Base value, TAdt (TBuiltin TBox, _)
-  | Base value, TRef _
-  | Base value, TRawPtr _ ->
-      let size = Typed.int Archi.word_size in
-      [ { value; ty = TInteger Isize; size; offset } ]
-  (* Fat pointers *)
-  | FatPtr (value, meta), TAdt (TBuiltin TBox, { types = [ sub_ty ]; _ })
-  | FatPtr (value, meta), TRef (_, sub_ty, _)
-  | FatPtr (value, meta), TRawPtr (sub_ty, _) ->
-      if is_fat_ptr sub_ty then
-        let size = Typed.int Archi.word_size in
-        let isize = Values.TInteger Isize in
-        [
-          { value :> cval; ty = isize; size; offset };
-          { value = meta; ty = isize; size; offset = offset +@ size };
-        ]
-      else
-        (* if a fat pointer is not requires, we ignore the metadata *)
-        let size = Typed.int Archi.word_size in
-        [ { value :> cval; ty = TInteger Isize; size; offset } ]
-  | _, TAdt (TBuiltin TBox, _) | _, TRawPtr _ | _, TRef _ -> illegal_pair ()
-  (* Tuples *)
-  | Tuple vs, TAdt (TTuple, { types; _ }) ->
-      if List.compare_lengths vs types <> 0 then
-        Fmt.failwith "Mistmached rust_val / TTuple lengths: %d/%d"
-          (List.length vs) (List.length types)
-      else chain_cvals (layout_of ty) vs types
-  | Tuple _, _ | _, TAdt (TTuple, _) -> illegal_pair ()
-  (* Structs *)
-  | Struct vals, TAdt (TAdtId t_id, _) ->
-      let type_decl = Session.get_adt t_id in
-      let fields =
-        match type_decl.kind with
-        | Struct fields -> field_tys fields
-        | _ ->
-            Fmt.failwith "Unexpected type declaration in struct value: %a"
-              Types.pp_type_decl type_decl
-      in
-      chain_cvals (layout_of ty) vals fields
-  | Struct _, _ -> illegal_pair ()
-  (* Enums *)
-  | Enum (disc, vals), TAdt (TAdtId t_id, _) ->
-      let type_decl = Session.get_adt t_id in
-      let disc_z =
-        match Typed.kind disc with
-        | Int d -> d
-        | k ->
-            Fmt.failwith "Unexpected enum discriminant kind: %a"
-              Svalue.pp_t_kind k
-      in
-      let variant =
-        match type_decl.kind with
-        | Enum variants ->
-            List.find
-              (fun v -> Z.equal disc_z Types.(v.discriminant.value))
-              variants
-        | _ ->
-            Fmt.failwith "Unexpected ADT type for enum: %a" Types.pp_type_decl
-              type_decl
-      in
-      let disc_ty = Types.TLiteral (TInteger variant.discriminant.int_ty) in
-      chain_cvals (of_variant variant) (Base disc :: vals)
-        (disc_ty :: field_tys variant.fields)
-  | Enum _, _ -> illegal_pair ()
-  (* Arrays *)
-  | Array vals, TAdt (TBuiltin TArray, { types = [ sub_ty ]; _ }) ->
-      let layout = layout_of ty in
-      let size = Array.length layout.members_ofs in
-      if List.length vals <> size then failwith "Array length mismatch"
-      else chain_cvals layout vals (List.init size (fun _ -> sub_ty))
-  | Array _, _ | _, TAdt (TBuiltin TArray, _) -> illegal_pair ()
-  (* Rest *)
-  | _ ->
-      L.err (fun m ->
-          m "Unhandled rust_value and Charon.ty: %a / %a" pp_rust_val v
-            Types.pp_ty ty);
-      failwith "Unhandled rust_value and Charon.ty"
-
-type aux_ret = (Types.literal_type * sint * sint) list * parse_callback
-and parse_callback = cval list -> callback_return
-and parser_return = [ `Done of rust_val | `More of aux_ret ]
-and callback_return = parser_return Rustsymex.t
-
-(** Converts a Rust type into a list of C blocks, along with their size and
-    offset; once these are read, symbolically decides whether we must keep
-    reading. @offset is the initial offset to read from, @meta is the optional
-    metadata, that originates from a fat pointer. *)
-let rust_of_cvals ?offset ?meta ty : parser_return =
-  (* Base case, parses all types. *)
-  let rec aux offset : Types.ty -> parser_return = function
-    | TLiteral ty ->
-        `More
-          ( [ (ty, Typed.int (size_of_literal_ty ty), offset) ],
-            function
-            | [ v ] -> return (`Done (Base v))
-            | _ -> failwith "Expected one cval" )
-    | TAdt (TBuiltin TBox, { types = [ sub_ty ]; _ })
-    | TRef (_, sub_ty, _)
-    | TRawPtr (sub_ty, _)
-      when is_fat_ptr sub_ty ->
-        let callback = function
-          | [ ptr; len ] ->
-              let* ptr =
-                of_opt_not_impl ~msg:"Slice value 1 should be a pointer"
-                  (Typed.cast_checked ptr Typed.t_ptr)
-              in
-              let+ len =
-                of_opt_not_impl ~msg:"Slice value 2 should be an integer"
-                  (Typed.cast_checked len Typed.t_int)
-              in
-              `Done (FatPtr (ptr, len))
-          | _ -> failwith "Expected two cvals"
-        in
-        let ptr_size = Typed.int Archi.word_size in
-        let isize = Values.TInteger Isize in
-        `More
-          ( [ (isize, ptr_size, offset); (isize, ptr_size, offset +@ ptr_size) ],
-            callback )
-    | TAdt (TBuiltin TBox, _) | TRef _ | TRawPtr _ ->
-        `More
-          ( [ (TInteger Isize, Typed.int Archi.word_size, offset) ],
-            function
-            | [ v ] -> (
-                match Typed.cast_checked v Typed.t_ptr with
-                | Some v_ptr -> return (`Done (Ptr v_ptr))
-                (* This should only happen on weird pointer casting. *)
-                | None -> return (`Done (Base v)))
-            | _ -> failwith "Expected one cval" )
-    | TAdt (TTuple, { types; _ }) as ty ->
-        let layout = layout_of ty in
-        aux_fields ~f:(fun fs -> Tuple fs) ~layout offset types
-    | TAdt (TAdtId t_id, _) as ty -> (
-        let type_decl = Session.get_adt t_id in
-        match (type_decl : Types.type_decl) with
-        | { kind = Enum variants; _ } -> aux_enum offset variants
-        | { kind = Struct fields; _ } ->
-            let layout = layout_of ty in
-            fields
-            |> field_tys
-            |> aux_fields ~f:(fun fs -> Struct fs) ~layout offset
-        | _ ->
-            Fmt.failwith "Unhandled type declaration in rust_of_cvals: %a"
-              Types.pp_type_decl type_decl)
-    | TAdt (TBuiltin TArray, { types = [ sub_ty ]; _ }) as ty ->
-        let layout = layout_of ty in
-        let len = Array.length layout.members_ofs in
-        let fields = List.init len (fun _ -> sub_ty) in
-        aux_fields ~f:(fun fs -> Array fs) ~layout offset fields
-    | TAdt (TBuiltin TSlice, { types = [ sub_ty ]; _ }) -> (
-        (* We can only read a slice if we have the metadata of its length, in which case
-           we interpret it as an array of that length. *)
-        match meta with
-        | None -> Fmt.failwith "Tried reading slice without metadata"
-        | Some meta ->
-            let len =
-              match Typed.kind meta with
-              | Int len -> Z.to_int len
-              | _ -> failwith "Can't read a slice of non-concrete size"
-            in
-            let arr_ty = mk_array_ty sub_ty len in
-            let layout = layout_of arr_ty in
-            let fields = List.init len (fun _ -> sub_ty) in
-            aux_fields ~f:(fun fs -> Array fs) ~layout offset fields)
-    | ty -> Fmt.failwith "Unhandled Charon.ty: %a" Types.pp_ty ty
-  (* Parses a list of fields (for structs and tuples) *)
-  and aux_fields ~f ~layout offset fields : parser_return =
-    let base_offset = offset +@ (offset %@ Typed.nonzero layout.align) in
-    let rec mk_callback to_parse parsed : parser_return =
-      match to_parse with
-      | [] -> `Done (f (List.rev parsed))
-      | ty :: rest -> (
-          let idx = List.length parsed in
-          let offset = Array.get layout.members_ofs idx |> Typed.int in
-          let offset = base_offset +@ offset in
-          match aux offset ty with
-          | `More (blocks, callback) ->
-              wrap_callback rest parsed blocks callback
-          | `Done value -> mk_callback rest (value :: parsed))
-    and wrap_callback to_parse parsed blocks callback =
-      `More
-        ( blocks,
-          fun values ->
-            let+ res = callback values in
-            match res with
-            | `More (blocks, callback) ->
-                wrap_callback to_parse parsed blocks callback
-            | `Done value -> mk_callback to_parse (value :: parsed) )
-    in
-    mk_callback fields []
-  (* Parses what enum variant we're handling *)
-  and aux_enum offset (variants : Types.variant list) : parser_return =
-    let disc = (List.hd variants).discriminant in
-    let disc_ty = Values.TInteger disc.int_ty in
-    let disc_align = Typed.nonzero (align_of_literal_ty disc_ty) in
-    let disc_size = Typed.int (size_of_literal_ty disc_ty) in
-    let offset = offset +@ (offset %@ disc_align) in
-    let callback cval : callback_return =
-      let cval = List.hd cval in
-      let* res =
-        match_on variants ~constr:(fun (v : Types.variant) ->
-            cval ==@ value_of_scalar v.discriminant)
-      in
-      match res with
-      | Some var ->
-          (* skip discriminant *)
-          let discr = value_of_scalar var.discriminant in
-          let ({ members_ofs = mems; _ } as layout) = of_variant var in
-          let members_ofs = Array.sub mems 1 (Array.length mems - 1) in
-          let layout = { layout with members_ofs } in
-          let parser =
-            var.fields
-            |> field_tys
-            |> aux_fields ~f:(fun fs -> Enum (discr, fs)) ~layout offset
-          in
-          return parser
-      | None ->
-          Fmt.kstr not_impl
-            "Vanishing rust_of_cvals, as no variant matches variant id %a"
-            Typed.ppa cval
-    in
-    `More ([ (TInteger disc.int_ty, disc_size, offset) ], callback)
-  in
-  let off = Option.value ~default:0s offset in
-  aux off ty

--- a/bfa_rust/lib/sptr.ml
+++ b/bfa_rust/lib/sptr.ml
@@ -1,0 +1,43 @@
+open Charon
+open Typed
+open T
+open Typed.Infix
+
+module type S = sig
+  (** pointer type *)
+  type t
+
+  val pp : t Fmt.t
+  val null_ptr : t
+  val is_null : t -> sbool Typed.t
+
+  (** [offset ~ty ptr off] Offsets [ptr] by the size of [ty] * [off]. [ty]
+      defaults to u8. *)
+  val offset : ?ty:Charon.Types.ty -> t -> sint Typed.t -> t
+
+  (** The metadata of the pointer, if it's a fat pointer *)
+  val meta : t -> T.cval Typed.t option
+
+  (** Sets the metadata of the pointer *)
+  val with_meta : t -> T.cval Typed.t option -> t
+end
+
+module T : S with type t = T.sptr Typed.t * T.cval Typed.t option = struct
+  type t = T.sptr Typed.t * T.cval Typed.t option
+
+  let pp fmt (ptr, meta) =
+    Format.fprintf fmt "(%a, %a)" Typed.ppa ptr
+      Fmt.(option ~none:(Fmt.any "-") Typed.ppa)
+      meta
+
+  let null_ptr = (Typed.Ptr.null, None)
+  let is_null (ptr, _) = Typed.Ptr.is_null ptr
+
+  let offset ?(ty = Types.TLiteral (TInteger U8)) (ptr, meta) off =
+    let { size; _ } : Layout.layout = Layout.layout_of ty in
+    let ptr' = Typed.Ptr.add_ofs ptr (Typed.int size *@ off) in
+    (ptr', meta)
+
+  let meta = snd
+  let with_meta (ptr, _) meta = (ptr, meta)
+end

--- a/bfa_rust/lib/sptr.ml
+++ b/bfa_rust/lib/sptr.ml
@@ -9,7 +9,14 @@ module type S = sig
 
   val pp : t Fmt.t
   val null_ptr : t
+
+  (** pointer equality, irrespective of metadata *)
+  val eq : t -> t -> sbool Typed.t
   val is_null : t -> sbool Typed.t
+  val is_same_loc : t -> t -> sbool Typed.t
+  val is_before : t -> t -> sbool Typed.t
+  val distance : t -> t -> sint Typed.t
+  val constraints : t -> sbool Typed.t
 
   (** [offset ~ty ptr off] Offsets [ptr] by the size of [ty] * [off]. [ty]
       defaults to u8. *)
@@ -19,7 +26,7 @@ module type S = sig
   val meta : t -> T.cval Typed.t option
 
   (** Sets the metadata of the pointer *)
-  val with_meta : t -> T.cval Typed.t option -> t
+  val with_meta : ?meta:(T.cval Typed.t) -> t -> t
 end
 
 module T : S with type t = T.sptr Typed.t * T.cval Typed.t option = struct
@@ -31,7 +38,22 @@ module T : S with type t = T.sptr Typed.t * T.cval Typed.t option = struct
       meta
 
   let null_ptr = (Typed.Ptr.null, None)
+  let eq (ptr1, _) (ptr2,_) = (ptr1 ==@ ptr2)
+
   let is_null (ptr, _) = Typed.Ptr.is_null ptr
+
+  let is_same_loc (ptr1, _) (ptr2, _) =
+    Typed.Ptr.loc ptr1 ==@ Typed.Ptr.loc ptr2
+
+  let is_before (ptr1, _) (ptr2, _) = Typed.Ptr.ofs ptr1 <@ Typed.Ptr.ofs ptr2
+
+  let distance (ptr1, _) (ptr2, _) = Typed.Ptr.ofs ptr1 -@ Typed.Ptr.ofs ptr2
+
+  let constraints =
+    let offset_constrs = Layout.int_constraints Values.Isize in
+    fun (ptr, _) ->
+      let ofs = Typed.Ptr.ofs ptr in
+      Typed.conj (offset_constrs ofs)
 
   let offset ?(ty = Types.TLiteral (TInteger U8)) (ptr, meta) off =
     let { size; _ } : Layout.layout = Layout.layout_of ty in
@@ -39,5 +61,5 @@ module T : S with type t = T.sptr Typed.t * T.cval Typed.t option = struct
     (ptr', meta)
 
   let meta = snd
-  let with_meta (ptr, _) meta = (ptr, meta)
+  let with_meta ?meta (ptr, _) = (ptr, meta)
 end

--- a/bfa_rust/lib/sptr.ml
+++ b/bfa_rust/lib/sptr.ml
@@ -11,10 +11,10 @@ module type S = sig
   val null_ptr : t
 
   (** Pointer equality, irrespective of metadata *)
-  val eq : t -> t -> sbool Typed.t
+  val sem_eq : t -> t -> sbool Typed.t
 
-  (** If this is the null pointer *)
-  val is_null : t -> sbool Typed.t
+  (** If this pointer is at a null location, i.e. has no provenance *)
+  val is_at_null_loc : t -> sbool Typed.t
 
   (** If these two pointers are at the same location (ie. same allocation) *)
   val is_same_loc : t -> t -> sbool Typed.t
@@ -53,8 +53,8 @@ struct
     | None -> Format.fprintf fmt "%a" Typed.ppa ptr
 
   let null_ptr = (Typed.Ptr.null, None)
-  let eq (ptr1, _) (ptr2, _) = ptr1 ==@ ptr2
-  let is_null (ptr, _) = Typed.Ptr.is_null ptr
+  let sem_eq (ptr1, _) (ptr2, _) = ptr1 ==@ ptr2
+  let is_at_null_loc (ptr, _) = Typed.Ptr.is_at_null_loc ptr
 
   let is_same_loc (ptr1, _) (ptr2, _) =
     Typed.Ptr.loc ptr1 ==@ Typed.Ptr.loc ptr2

--- a/bfa_rust/lib/std_funs.ml
+++ b/bfa_rust/lib/std_funs.ml
@@ -8,6 +8,12 @@ open Charon_util
 module T = Typed.T
 
 module M (Heap : Heap_intf.S) = struct
+  module Sptr = Heap.Sptr
+
+  type nonrec rust_val = Sptr.t rust_val
+
+  let pp_rust_val = pp_rust_val Sptr.pp
+
   type std_op = Add | Sub | Mul | Div | Rem
   type std_bool = Id | Neg
   type type_loc = GenArg | Input
@@ -231,32 +237,6 @@ module M (Heap : Heap_intf.S) = struct
     in
     let** left, right, state =
       match fun_sig.inputs with
-      | Types.TRef
-          ( _,
-            (TRef (_, TAdt (TBuiltin TSlice, { types = [ ty ]; _ }), _) as
-             outer_ty),
-            _ )
-        :: _ ->
-          (* STD provides an implementation of eq for slices (&[T]), we kind of cheat by converting
-             them to arrays, to make life easier *)
-          let** left, state = Heap.load left_ptr outer_ty state in
-          let** right, state = Heap.load right_ptr outer_ty state in
-          let left_ptr, len_left, right_ptr, len_right =
-            match (left, right) with
-            (* really not great but not sure how else to do it for now without it being hell *)
-            | FatPtr (pl, l), FatPtr (pr, r) -> (
-                match (Typed.kind l, Typed.kind r) with
-                | Int l, Int r -> (pl, Z.to_int l, pr, Z.to_int r)
-                | _ ->
-                    failwith "eq_values expects two slices of non-symbolic size"
-                )
-            | _ -> failwith "eq_values expects two slices"
-          in
-          let ty_left = mk_array_ty ty len_left in
-          let ty_right = mk_array_ty ty len_right in
-          let** left, state = Heap.load left_ptr ty_left state in
-          let++ right, state = Heap.load right_ptr ty_right state in
-          (left, right, state)
       | Types.TRef (_, (TRef (_, ty, _) as outer_ty), _) :: _ ->
           (* STD provides an implementation of eq for references (&T), where the arguments are
              thus &&T -- we handle this here by adding an indirection. *)
@@ -295,7 +275,7 @@ module M (Heap : Heap_intf.S) = struct
       ~state =
     let rec aux : Types.ty -> rust_val = function
       | TLiteral _ -> Base Typed.zero
-      | TRawPtr _ | TRef _ -> Ptr Typed.Ptr.null
+      | TRawPtr _ | TRef _ -> Ptr Sptr.null_ptr
       | TAdt (TAdtId t_id, _) -> (
           let adt = Types.TypeDeclId.Map.find t_id crate.type_decls in
           match adt.kind with
@@ -326,12 +306,12 @@ module M (Heap : Heap_intf.S) = struct
 
   let array_index (idx_op : Expressions.builtin_index_op)
       (gen_args : Types.generic_args) ~crate:_ ~args ~state =
-    let ptr, size =
-      match (idx_op.is_array, args, gen_args.const_generics) with
+    let ptr = as_ptr @@ List.hd args in
+    let size =
+      match (idx_op.is_array, Sptr.meta ptr, gen_args.const_generics) with
       (* Array with static size *)
-      | true, Ptr ptr :: _, [ size ] ->
-          (ptr, Typed.int @@ Charon_util.int_of_const_generic size)
-      | false, FatPtr (ptr, size) :: _, [] -> (ptr, Typed.cast size)
+      | true, _, [ size ] -> Typed.int @@ Charon_util.int_of_const_generic size
+      | false, Some size, [] -> Typed.cast size
       | _ ->
           Fmt.failwith "array_index: unexpected arguments: %a / %a"
             Fmt.(list pp_rust_val)
@@ -343,15 +323,15 @@ module M (Heap : Heap_intf.S) = struct
     let idx = as_base_of ~ty:Typed.t_int (List.nth args 1) in
     if%sat 0s <=@ idx &&@ (idx <@ size) then
       let ty = List.hd gen_args.types in
-      let* offset = Layout.size_of_s ty in
-      let ptr' = Typed.Ptr.add_ofs ptr (offset *@ idx) in
+      let ptr' = Sptr.offset ~ty ptr idx in
       if not idx_op.is_range then Result.ok (Ptr ptr', state)
       else
         let range_end = as_base_of ~ty:Typed.t_int (List.nth args 2) in
         (* range_end is exclusive *)
         if%sat idx <=@ range_end &&@ (range_end <=@ size) then
           let size = range_end -@ idx in
-          Result.ok (FatPtr (ptr', size), state)
+          let ptr' = Sptr.with_meta ptr' (Some size) in
+          Result.ok (Ptr ptr', state)
         else
           (* not sure this is the right diagnostic *)
           Heap.error `OutOfBounds state
@@ -382,7 +362,7 @@ module M (Heap : Heap_intf.S) = struct
       match (args, gargs.const_generics) with
       (* Array with static size *)
       | _, [ size ] -> Typed.int @@ Charon_util.int_of_const_generic size
-      | FatPtr (_, size) :: _, [] -> Typed.cast size
+      | Ptr ptr :: _, [] -> Typed.cast @@ Option.get @@ Sptr.meta ptr
       | _ -> failwith "array_index (fn): couldn't calculate size"
     in
     let ptr, idx_from, idx_to =
@@ -410,17 +390,14 @@ module M (Heap : Heap_intf.S) = struct
       | [ size ] -> Charon_util.int_of_const_generic size
       | _ -> failwith "array_slice: unexpected generic constants"
     in
-    let arr_ptr =
-      match args with
-      | [ Ptr arr_ptr ] -> arr_ptr
-      | _ -> failwith "array_index: unexpected arguments"
-    in
-    let slice = FatPtr (arr_ptr, Typed.int size) in
-    Result.ok (slice, state)
+    match args with
+    | [ Ptr (arr_ptr, None) ] ->
+        Result.ok (Ptr (arr_ptr, Some (Typed.int size)), state)
+    | _ -> failwith "array_index: unexpected arguments"
 
   let slice_len _ ~crate:_ ~args ~state =
     match args with
-    | [ FatPtr (_, len) ] -> Result.ok (Base len, state)
+    | [ Ptr (_, Some len) ] -> Result.ok (Base len, state)
     | _ -> failwith "slice_len: unexpected arguments"
 
   let discriminant_value (funsig : GAst.fun_sig) ~crate:_ ~args ~state =
@@ -441,21 +418,19 @@ module M (Heap : Heap_intf.S) = struct
 
   let to_string _ ~crate:_ ~args ~state =
     match args with
-    | [ (FatPtr (_, len) as slice) ] ->
+    | [ (Ptr (_, Some len) as slice) ] ->
         Result.ok (Struct [ slice; Base len ], state)
     | _ -> failwith "to_string: unexpected value"
 
   let str_chars _ ~crate:_ ~args ~state =
     let ptr, len =
       match args with
-      | [ FatPtr (ptr, len) ] -> (ptr, len)
+      | [ Ptr ((_, Some len) as ptr) ] -> (ptr, len)
       | _ -> failwith "str_chars: unexpected value"
     in
     let len = Typed.cast len in
-    let ptr_loc, ptr_off = Typed.Ptr.decompose ptr in
-    let ty_size = Layout.size_of_literal_ty TChar in
-    let arr_end_ofs = ptr_off +@ (Typed.int ty_size *@ len) in
-    let arr_end = Typed.Ptr.mk ptr_loc arr_end_ofs in
+    let ty = Types.TLiteral TChar in
+    let arr_end = Sptr.offset ~ty ptr len in
     Result.ok (Struct [ Ptr ptr; Ptr arr_end ], state)
 
   let iter_nth (fun_sig : GAst.fun_sig) ~crate ~args ~state =
@@ -485,12 +460,13 @@ module M (Heap : Heap_intf.S) = struct
       | Struct [ Ptr start_ptr; Ptr end_ptr ] -> (start_ptr, end_ptr)
       | _ -> failwith "iter_nth: unexpected iter structure"
     in
-    let start_loc, start_ofs = Typed.Ptr.decompose start_ptr in
-    let end_loc, end_ofs = Typed.Ptr.decompose end_ptr in
+    let start_loc, start_ofs = Typed.Ptr.decompose @@ fst start_ptr in
+    let end_loc, end_ofs = Typed.Ptr.decompose @@ fst end_ptr in
     if%sat start_loc ==@ end_loc then
       let ofs = start_ofs +@ (idx *@ sub_ty_size) in
       if%sat ofs <@ end_ofs then
         let ptr = Typed.Ptr.mk start_loc ofs in
+        let ptr = (ptr, None) in
         let iter' = Struct [ Ptr ptr; Ptr end_ptr ] in
         let** value, state = Heap.load ptr sub_ty state in
         let++ (), state = Heap.store iter_ptr iter_ty iter' state in
@@ -530,7 +506,7 @@ module M (Heap : Heap_intf.S) = struct
     in
     let++ str_obj, state = Heap.load str_ptr str_ty state in
     match str_obj with
-    | Struct [ FatPtr (_, len); _ ] -> (Base len, state)
+    | Struct [ Ptr (_, Some len); _ ] -> (Base len, state)
     | _ -> failwith "str_len: unexpected string type"
 
   let assert_zero_is_valid (fun_sig : GAst.fun_sig) ~crate:_ ~args:_ ~state =
@@ -595,12 +571,10 @@ module M (Heap : Heap_intf.S) = struct
       | _ -> failwith "ptr_offset_from: invalid arguments"
     in
     let offset_constrs = Layout.int_constraints Values.Isize in
-    let* size = Layout.size_of_s ty in
-    let loc, ofs = Typed.Ptr.decompose ptr in
-    let** ofs' = op ofs (v *@ size) state in
-    if%sat Typed.conj (offset_constrs ofs') then
-      let ptr' = Typed.Ptr.mk loc ofs' in
-      Result.ok (Ptr ptr', state)
+    let v = if op = Add then v else ~-v in
+    let ptr' = Sptr.offset ~ty ptr v in
+    let ofs' = Typed.Ptr.ofs @@ fst ptr' in
+    if%sat Typed.conj (offset_constrs ofs') then Result.ok (Ptr ptr', state)
     else Heap.error `Overflow state
 
   let box_into_raw _ ~crate:_ ~args ~state =
@@ -611,7 +585,7 @@ module M (Heap : Heap_intf.S) = struct
   let ptr_offset_from (funsig : GAst.fun_sig) ~crate:_ ~args ~state =
     let ptr1, ptr2 =
       match args with
-      | [ Ptr ptr1; Ptr ptr2 ] -> (ptr1, ptr2)
+      | [ Ptr (ptr1, _); Ptr (ptr2, _) ] -> (ptr1, ptr2)
       | _ -> failwith "ptr_offset_from: invalid arguments"
     in
     let ty =
@@ -775,7 +749,7 @@ module M (Heap : Heap_intf.S) = struct
        | IterNth -> iter_nth f.signature
        | MinAlignOf t -> min_align_of ~in_input:(t = Input) f.signature
        | OptUnwrap -> unwrap_opt f.signature
-       | PtrOp op -> ptr_op (op_of op) f.signature
+       | PtrOp op -> ptr_op op f.signature
        | PtrOffsetFrom -> ptr_offset_from f.signature
        | ResUnwrap -> unwrap_res f.signature
        | SizeOf -> size_of f.signature

--- a/bfa_rust/lib/std_funs.ml
+++ b/bfa_rust/lib/std_funs.ml
@@ -463,7 +463,8 @@ module M (Heap : Heap_intf.S) = struct
     in
     if%sat Sptr.is_same_loc start_ptr end_ptr then
       let ptr = Sptr.offset ~ty:sub_ty start_ptr idx in
-      if%sat Sptr.is_before ptr end_ptr then
+      let dist = Sptr.distance ptr end_ptr in
+      if%sat dist <@ 0s then
         let iter' = Struct [ Ptr ptr; Ptr end_ptr ] in
         let** value, state = Heap.load ptr sub_ty state in
         let++ (), state = Heap.store iter_ptr iter_ty iter' state in

--- a/bfa_rust/lib/std_funs.ml
+++ b/bfa_rust/lib/std_funs.ml
@@ -392,7 +392,7 @@ module M (Heap : Heap_intf.S) = struct
     in
     match args with
     | [ Ptr arr_ptr ] ->
-      let ptr' = Sptr.with_meta ~meta:(Typed.int size) arr_ptr in
+        let ptr' = Sptr.with_meta ~meta:(Typed.int size) arr_ptr in
         Result.ok (Ptr ptr', state)
     | _ -> failwith "array_index: unexpected arguments"
 
@@ -419,7 +419,7 @@ module M (Heap : Heap_intf.S) = struct
 
   let to_string _ ~crate:_ ~args ~state =
     match args with
-    | [ (Ptr (ptr) as slice) ] ->
+    | [ (Ptr ptr as slice) ] ->
         Result.ok (Struct [ slice; Base (Option.get @@ Sptr.meta ptr) ], state)
     | _ -> failwith "to_string: unexpected value"
 
@@ -569,7 +569,7 @@ module M (Heap : Heap_intf.S) = struct
     in
     let v = if op = Add then v else ~-v in
     let ptr' = Sptr.offset ~ty ptr v in
-    if%sat Sptr.constraints ptr'  then Result.ok (Ptr ptr', state)
+    if%sat Sptr.constraints ptr' then Result.ok (Ptr ptr', state)
     else Heap.error `Overflow state
 
   let box_into_raw _ ~crate:_ ~args ~state =


### PR DESCRIPTION
The interpreter currently manipulates pointers directly -- this is possible because we are in monomorphised code, where all field offsets are known. To enable Ruxt, that runs on polymorphic code, we must abstract this away.

Added a module `Sptr` that does just this -- it abstracts a pointer and its metadata (for fat pointers). Moved the current pointer arithmetic logic to a module `ArithPtr`. The interpreter and STD functions are now parametric on the pointer module, that is provided by the heap module.

The logic for converting to and from C values to rust_val has also been moved to an `encoder.ml` file, to allow `Layout.ml` to work irrespective of the pointer type (while `encoder.ml` assumes `ArithPtr` is used).