### PR TITLE
Change CI to build a Docker image

### DIFF
--- a/.docker/all-deps.Dockerfile
+++ b/.docker/all-deps.Dockerfile
@@ -1,0 +1,75 @@
+# Use a minimal Alpine-based OCaml image
+FROM ocaml/opam:debian-12-ocaml-5.3-flambda
+
+WORKDIR /tmp
+
+# Setup Node.js repository
+RUN curl -fsSL https://deb.nodesource.com/setup_23.x | bash
+
+# Install apt dependencies
+RUN sudo apt-get update && \
+  sudo apt-get install -y --no-install-recommends \
+  libgmp-dev \
+  m4 \
+  pkg-config \
+  unzip \
+  ca-certificates \
+  nodejs && \
+  sudo rm -rf /var/lib/apt/lists/*
+
+# Switch to the default opam user
+USER opam
+
+# Install Z3 solver from GitHub release
+RUN curl -L https://github.com/Z3Prover/z3/releases/download/z3-4.14.1/z3-4.14.1-arm64-glibc-2.34.zip -o z3-4.14.1-arm64-glibc-2.34.zip && \
+  unzip z3-4.14.1-arm64-glibc-2.34.zip -d z3 && \
+  sudo cp z3/z3-4.14.1-arm64-glibc-2.34/bin/z3 /usr/bin/ && \
+  sudo chmod +x /usr/bin/z3 && \
+  rm -rf z3 z3-4.14.1-arm64-glibc-2.34.zip
+
+# Install yq to read yaml files
+RUN curl -L https://github.com/mikefarah/yq/releases/download/v4.45.1/yq_linux_arm64 -o yq && \
+  sudo cp yq /usr/bin/yq && \
+  sudo chmod +x /usr/bin/yq && \
+  rm -f yq && \
+  yq --version
+
+# Install the specific Rust version required for Charon
+WORKDIR /charon
+RUN git init && \
+  git remote add origin https://github.com/N1ark/charon.git && \
+  git fetch --depth=1 origin 24cce6151f166ec540ef3daa24112d0e3ace4aad && \
+  git checkout 24cce6151f166ec540ef3daa24112d0e3ace4aad
+
+RUN (curl https://sh.rustup.rs -sSf | \
+  bash -s -- -y \
+  --default-toolchain "$(yq '.toolchain.channel' rust-toolchain -p toml -oy)" \
+  --component "$(yq '.toolchain.components | join(",")' rust-toolchain -p toml -oy)" \
+  --profile minimal \
+  --no-update-default-toolchain)
+
+
+ENV PATH="/home/opam/.cargo/bin:${PATH}"
+RUN rustup --version
+
+# Build Charon
+RUN make build-dev-charon-rust && \
+  sudo mv /charon/bin/* /usr/bin/ && \
+  sudo chmod +x /usr/bin/charon && \
+  cd /charon/charon && \
+  cargo clean -Z gc && \
+  cd / \
+  && sudo rm -rf /charon
+
+WORKDIR /soteria
+
+RUN charon --help
+
+# Copy only the opam file to install all dependencies (better for caching)
+COPY --chown=opam:opam bfa.opam bfa-c.opam bfa-rust.opam bfa-vscode.opam /soteria/
+RUN opam install ./bfa.opam ./bfa-c.opam ./bfa-rust.opam ./bfa-vscode.opam --with-test --with-docT --deps-only -y && \
+  opam clean -a -c -s --logs
+
+
+
+

--- a/.docker/bfa-c.Dockerfile
+++ b/.docker/bfa-c.Dockerfile
@@ -1,0 +1,38 @@
+# Use a minimal Alpine-based OCaml image
+FROM ocaml/opam:debian-ocaml-5.3-flambda
+
+# Set working directory
+WORKDIR /app
+
+# Install only necessary system dependencies
+RUN sudo apt-get update && sudo apt-get install -y \
+  m4 \
+  libgmp-dev \
+  pkg-config
+
+# Switch to the default opam user
+USER opam
+
+# Install Z3 solver from GitHub release
+RUN sudo apt-get install -y wget unzip && \
+  wget https://github.com/Z3Prover/z3/releases/download/z3-4.14.1/z3-4.14.1-arm64-glibc-2.34.zip && \
+  unzip z3-4.14.1-arm64-glibc-2.34.zip -d z3 && \
+  sudo cp z3/z3-4.14.1-arm64-glibc-2.34/bin/z3 /usr/bin/ && \
+  sudo chmod +x /usr/bin/z3 && \
+  rm -rf z3 z3-4.14.1-arm64-glibc-2.34.zip
+
+# Initialize opam environment and install dependencies
+RUN opam update
+
+# Copy only the opam file to install all dependencies (better for caching)
+COPY --chown=opam:opam bfa.opam bfa-c.opam /app/
+RUN opam install ./bfa.opam ./bfa-c.opam --deps-only -y
+
+# Copy the rest of the project files
+COPY --chown=opam:opam . /app
+
+
+RUN opam install ./bfa.opam ./bfa-c.opam -y
+
+# Set the default command
+CMD ["opam", "exec", "--", "bfa-c", "lsp"]

--- a/.docker/soteria-c-deps.Dockerfile
+++ b/.docker/soteria-c-deps.Dockerfile
@@ -1,0 +1,19 @@
+FROM soteria-deps:latest
+
+USER root
+
+WORKDIR /tmp
+
+RUN curl -fsSL https://deb.nodesource.com/setup_23.x | bash
+RUN apt-get install -y nodejs
+
+USER opam
+
+WORKDIR /soteria
+
+COPY --chown=opam:opam bfa-c.opam ./bfa-vscode.opam /soteria/
+
+RUN opam install ./bfa.opam ./bfa-c.opam ./bfa-vscode.opam --with-test --with-doc --deps-only -y
+
+COPY --chown=opam:opam . /soteria/
+RUN opam install ./bfa.opam -y

--- a/.docker/soteria-c.Dockerfile
+++ b/.docker/soteria-c.Dockerfile
@@ -1,0 +1,8 @@
+FROM soteria-c-deps:latest
+
+USER opam
+WORKDIR /soteria
+
+RUN opam exec -- dune build -p bfa-c
+RUN opam exec -- dune test bfa_c
+RUN opam install ./bfa-c.opam -y

--- a/.docker/soteria-deps.Dockerfile
+++ b/.docker/soteria-deps.Dockerfile
@@ -1,29 +1,31 @@
 # Use a minimal Alpine-based OCaml image
-FROM ocaml/opam:debian-ocaml-5.3-flambda
+FROM ocaml/opam:debian-12-ocaml-5.3-flambda
 
 # Set working directory
 WORKDIR /soteria
 
 # Install only necessary system dependencies
-RUN sudo apt-get update && sudo apt-get install -y \
-  m4 \
+RUN sudo apt-get update && \
+  sudo apt-get install -y --no-install-recommends \
   libgmp-dev \
-  pkg-config
+  m4 \
+  pkg-config \
+  wget \
+  unzip \
+  ca-certificates && \
+  sudo rm -rf /var/lib/apt/lists/*
 
 # Switch to the default opam user
 USER opam
 
 # Install Z3 solver from GitHub release
-RUN sudo apt-get install -y wget unzip && \
-  wget https://github.com/Z3Prover/z3/releases/download/z3-4.14.1/z3-4.14.1-arm64-glibc-2.34.zip && \
+RUN wget https://github.com/Z3Prover/z3/releases/download/z3-4.14.1/z3-4.14.1-arm64-glibc-2.34.zip && \
   unzip z3-4.14.1-arm64-glibc-2.34.zip -d z3 && \
   sudo cp z3/z3-4.14.1-arm64-glibc-2.34/bin/z3 /usr/bin/ && \
   sudo chmod +x /usr/bin/z3 && \
   rm -rf z3 z3-4.14.1-arm64-glibc-2.34.zip
 
-# Initialize opam environment and install dependencies
-RUN opam update
-
 # Copy only the opam file to install all dependencies (better for caching)
 COPY --chown=opam:opam bfa.opam /soteria/
-RUN opam install ./bfa.opam --with-test --with-doc --deps-only -y
+RUN opam install ./bfa.opam --with-test --with-doc --deps-only -y && \
+  opam clean -a -c -s --logs

--- a/.docker/soteria-deps.Dockerfile
+++ b/.docker/soteria-deps.Dockerfile
@@ -2,7 +2,7 @@
 FROM ocaml/opam:debian-ocaml-5.3-flambda
 
 # Set working directory
-WORKDIR /app
+WORKDIR /soteria
 
 # Install only necessary system dependencies
 RUN sudo apt-get update && sudo apt-get install -y \
@@ -25,14 +25,5 @@ RUN sudo apt-get install -y wget unzip && \
 RUN opam update
 
 # Copy only the opam file to install all dependencies (better for caching)
-COPY --chown=opam:opam bfa.opam bfa-c.opam /app/
-RUN opam install ./bfa.opam ./bfa-c.opam --deps-only -y
-
-# Copy the rest of the project files
-COPY --chown=opam:opam . /app
-
-
-RUN opam install ./bfa.opam ./bfa-c.opam -y
-
-# Set the default command
-CMD ["opam", "exec", "--", "bfa-c", "lsp"]
+COPY --chown=opam:opam bfa.opam /soteria/
+RUN opam install ./bfa.opam --with-test --with-doc --deps-only -y

--- a/.docker/soteria-rust-deps.Dockerfile
+++ b/.docker/soteria-rust-deps.Dockerfile
@@ -1,0 +1,23 @@
+FROM soteria-deps:latest
+
+USER opam
+
+RUN curl https://sh.rustup.rs -sSf | bash -s -- -y
+ENV PATH="/home/opam/.cargo/bin:${PATH}"
+
+WORKDIR /charon
+RUN git init && \
+  git remote add origin https://github.com/N1ark/charon.git && \
+  git fetch --depth=1 origin 24cce6151f166ec540ef3daa24112d0e3ace4aad && \
+  git checkout 24cce6151f166ec540ef3daa24112d0e3ace4aad
+
+RUN make build-dev-charon-rust
+ENV PATH="/charon/bin:${PATH}"
+
+WORKDIR /soteria
+
+COPY --chown=opam:opam ./bfa-rust.opam /soteria/
+RUN opam install ./bfa.opam ./bfa-rust.opam --with-test --with-doc --deps-only -y
+
+COPY --chown=opam:opam . /soteria/
+RUN opam install ./bfa.opam -y

--- a/.docker/soteria-rust.Dockerfile
+++ b/.docker/soteria-rust.Dockerfile
@@ -1,0 +1,9 @@
+FROM soteria-rust-deps:latest
+
+USER opam
+
+WORKDIR /soteria
+
+RUN opam exec -- dune build -p bfa-rust
+RUN opam exec -- dune test bfa_rust
+RUN opam install ./bfa-rust.opam -y

--- a/.docker/tests.Dockerfile
+++ b/.docker/tests.Dockerfile
@@ -1,0 +1,8 @@
+FROM all-deps:latest
+
+WORKDIR /soteria
+
+COPY --chown=opam:opam . .
+RUN opam exec -- dune build @all
+RUN opam exec -- dune test
+RUN opam exec -- dune build @fmt

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,4 @@
+_opam
+node_modules
+_build
+package

--- a/.dockerignore
+++ b/.dockerignore
@@ -2,4 +2,6 @@ _opam
 node_modules
 _build
 package
+.docker
 .git
+*.log

--- a/.dockerignore
+++ b/.dockerignore
@@ -2,3 +2,4 @@ _opam
 node_modules
 _build
 package
+.git

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,68 +19,12 @@ jobs:
     steps:
       # Setup steps: checkout, z3, node, ocaml
       - uses: actions/checkout@v4
-      - name: Setup Z3
-        uses: cda-tum/setup-z3@v1
-        id: z3
-      - name: Setup Rust
-        uses: actions-rust-lang/setup-rust-toolchain@v1
-      - name: Setup Charon
-        run: |
-          brew install make
-          cd ..
-          git clone https://github.com/N1ark/charon.git
-          cd charon
-          git checkout 24cce6151f166ec540ef3daa24112d0e3ace4aad
-          gmake build-dev-charon-rust
-          echo "$PWD/bin" >> $GITHUB_PATH
-      - name: Setup node
-        uses: actions/setup-node@v4
-      - name: Setup OCaml
-        uses: ocaml/setup-ocaml@v3
-        with:
-          ocaml-compiler: 5.3.0
-          dune-cache: true
       # OCaml build and tests
-      - run: opam update
-      - name: setup dependencies
-        run: make ocaml-deps
-      - name: Build OCaml stuff
-        run: make ocaml
-      - name: test
-        run: Make ocaml-test
       # Building js stuff
-      - name: Install JS dependencies
-        run: yarn install
-      - name: Build JS stuff
-        run: yarn compile
       # Packaging OCaml distribution and sending it as artifact
-      - name: OCaml zip file creation
-        run: make package
-      - name: Upload zip file
-        uses: actions/upload-artifact@v4
+      - uses: docker/setup-buildx-action@v3
         with:
-          name: ${{ matrix.operating-system }}-package
-          path: package
-          if-no-files-found: error
-
-  test-package:
-    strategy:
-      matrix:
-        operating-system: [macos-latest, macos-13]
-    runs-on: ${{ matrix.operating-system }}
-    needs: build
-    steps:
-      - name: Download package
-        uses: actions/download-artifact@v4
-        with:
-          name: ${{ matrix.operating-system }}-package
-      - name: Add executable permissions
-        run: |
-          chmod +x ./bin/bfa-c
-          chmod +x ./bin/z3
-      - name: Write dummy C file
-        run: echo "int main() { return 12; }" > test.c
-      - run: DYLD_LIBRARY_PATH=./lib:$DYLD_LIBRARY_PATH ./bin/bfa-c exec-main test.c
-        env:
-          BFA_Z3_PATH: ./bin/z3
-          CERB_INSTALL_PREFIX: .
+          version: latest
+          install: true
+      - run: docker build -t all-deps -f .docker/all-deps.Dockerfile .
+      - run: docker build -f .docker/tests/Dockerfile .


### PR DESCRIPTION
There might be something more clever here. For instance, instead of building the second image to run the tests, we might be able to run directly the next steps [*in* the `all-deps` container](https://docs.github.com/en/actions/writing-workflows/choosing-where-your-workflow-runs/running-jobs-in-a-container). This raises questions on detecting that a new image must be built and running this as a first step, but it might work. We might, for instance, store the all-deps image on ghcr for the dependencies that are on the `main` branch, and if dependencies change in a branch, we build the image locally and cache it or something?

TODOS:
- [ ] Send built image to cache and re-use it if it exists